### PR TITLE
add unit tests coverage reports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.js', '!src/**/stories/*'],
+  collectCoverageFrom: ['src/**/*.tsx', 'src/**/*.ts', '!src/entry.ts'],
   coverageDirectory: './coverage/',
   moduleNameMapper: {
     '\\.(css|scss)$': '<rootDir>/__mocks__/styleMock.js',

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "HAC Infrastructure Plugin",
   "scripts": {
     "prod": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
+    "coverage": "jest --coverage --runInBand --detectOpenHandles --forceExit",
     "dev": "BETA=true webpack serve --config config/dev.webpack.config.js",
     "dev:federated": "BETA=true fec static --config config/dev.webpack.config.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --color",

--- a/test.sh
+++ b/test.sh
@@ -3,5 +3,9 @@ set -euo pipefail
 
 yarn install
 yarn prod
-yarn test
+yarn coverage
 yarn lint
+
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+chmod +x codecov
+./codecov -t ${CODECOV_TOKEN} --dir ./coverage


### PR DESCRIPTION
Hi @jhadvig added a new `coverage` script which can be used to run unit test and generate coverage report, I'm not sure if I should update existing `test` script or a new one. Could you help review? 