### PR TITLE
Bump up Core SDK version + update custom proxy

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -27,7 +27,24 @@ const webpackProxy = {
     localChrome: process.env.INSIGHTS_CHROME,
   }),
   customProxy: [
-    // TODO
+    {
+      context: (path) => path.includes('/api/k8s'),
+      target: 'https://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443',
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: true,
+      pathRewrite: { '^/api/k8s': '' },
+    },
+    {
+      context: (path) => path.includes('/wss/k8s'),
+      target: 'wss://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443',
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: true,
+      pathRewrite: { '^/wss/k8s': '' },
+    },
   ],
   client: {
     overlay: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha2",
+        "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha7",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
         "@redhat-cloud-services/frontend-components-config": "^4.5.6",
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.9",
@@ -1470,9 +1470,9 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-webpack": {
-      "version": "1.0.0-alpha4",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha4.tgz",
-      "integrity": "sha512-8cvZpMQyU6Tk+VQZMckNIARNuf5dhhj44OF9fN82hugefok8J3uMOxzRc4zZD6R56/P6sZT2khqIqVCwDjB7Sw==",
+      "version": "1.0.0-alpha7",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha7.tgz",
+      "integrity": "sha512-bQ2eO44Q2qSvMAhwV7dKi07fVZAIJURqHYwbecYXcBMqE+nZ4F5YNeUnre6J2NsipeDRypU/O2ON6tSb9viqTw==",
       "dev": true,
       "dependencies": {
         "glob": "^7.2.0",
@@ -16695,9 +16695,9 @@
       }
     },
     "@openshift/dynamic-plugin-sdk-webpack": {
-      "version": "1.0.0-alpha4",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha4.tgz",
-      "integrity": "sha512-8cvZpMQyU6Tk+VQZMckNIARNuf5dhhj44OF9fN82hugefok8J3uMOxzRc4zZD6R56/P6sZT2khqIqVCwDjB7Sw==",
+      "version": "1.0.0-alpha7",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha7.tgz",
+      "integrity": "sha512-bQ2eO44Q2qSvMAhwV7dKi07fVZAIJURqHYwbecYXcBMqE+nZ4F5YNeUnre6J2NsipeDRypU/O2ON6tSb9viqTw==",
       "dev": true,
       "requires": {
         "glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha2",
+    "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha7",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
     "@redhat-cloud-services/frontend-components-config": "^4.5.6",
     "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.9",


### PR DESCRIPTION
This PR updates `@openshift/dynamic-plugin-sdk-webpack` to the latest published version.

It also updates the custom proxy in the webpack config (similar to hac-dev) in preparation for future stories on displaying workspaces in a list. 