### PR TITLE
[HAC-1854] Remove console.navigation extension

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -26,13 +26,6 @@ module.exports = {
         name: 'Workspaces',
       },
     },
-    {
-      type: 'console.navigation/href',
-      properties: {
-        href: '/workspaces',
-        name: 'Workspaces',
-      },
-    },
   ],
   sharedModules: {
     '@openshift/dynamic-plugin-sdk': { singleton: true, import: false },


### PR DESCRIPTION
https://issues.redhat.com/browse/HAC-1854

Test:

Following the instructions from the Readme to load HAC Infra on the browser, we should still see the `Workspaces` menu item in the navigation menu on the left.

cc: @rhamilto 