### PR TITLE
HAC-1618: Add create workspace modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@types/jest": "^27.4.0",
+        "@types/jest-axe": "^3.5.4",
         "@types/react": "^17.0.39",
         "@types/react-helmet": "^6.1.5",
         "@typescript-eslint/eslint-plugin": "^5.11.0",
@@ -35,6 +36,7 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-react-hooks": "^4.3.0",
         "jest": "^27.4.2",
+        "jest-axe": "^6.0.0",
         "npm-run-all": "4.1.5",
         "react-redux": "^7.2.2",
         "react-router-dom": "^6.3.0",
@@ -1762,6 +1764,16 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "node_modules/@types/jest-axe": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.4.tgz",
+      "integrity": "sha512-S0M+Etke9v3o0PjjfA4ijoU8G0+eI+lblpGYFYw2t+PPPnPPzJBX7UKLoQjz1SfIp+Hf/bNMFvoBX8zlFVzdrQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2896,6 +2908,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -7283,6 +7304,61 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-axe": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-6.0.0.tgz",
+      "integrity": "sha512-gAh/2zoWii4Rbhe6IUIo5TTiseGJDCitFnDFwBNpIuaOciyQgVZue6jtd4W7oMoKHewKoRSuIol7t/MuGx+mqg==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "4.4.1",
+        "chalk": "4.1.0",
+        "jest-matcher-utils": "27.0.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
+      "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.0.2",
+        "jest-get-type": "^27.0.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-changed-files": {
@@ -15073,6 +15149,16 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "@types/jest-axe": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.4.tgz",
+      "integrity": "sha512-S0M+Etke9v3o0PjjfA4ijoU8G0+eI+lblpGYFYw2t+PPPnPPzJBX7UKLoQjz1SfIp+Hf/bNMFvoBX8zlFVzdrQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -15963,6 +16049,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
       "dev": true
     },
     "axios": {
@@ -19224,6 +19316,48 @@
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
         "jest-cli": "^27.5.1"
+      }
+    },
+    "jest-axe": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-6.0.0.tgz",
+      "integrity": "sha512-gAh/2zoWii4Rbhe6IUIo5TTiseGJDCitFnDFwBNpIuaOciyQgVZue6jtd4W7oMoKHewKoRSuIol7t/MuGx+mqg==",
+      "dev": true,
+      "requires": {
+        "axe-core": "4.4.1",
+        "chalk": "4.1.0",
+        "jest-matcher-utils": "27.0.2",
+        "lodash.merge": "4.6.2"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+          "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
+          "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^27.0.2",
+            "jest-get-type": "^27.0.1",
+            "pretty-format": "^27.0.2"
+          }
+        }
       }
     },
     "jest-changed-files": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@testing-library/react": "^12.1.2",
     "@types/jest": "^27.4.0",
     "@types/react": "^17.0.39",
+    "@types/jest-axe": "^3.5.4",
     "@types/react-helmet": "^6.1.5",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
@@ -45,6 +46,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-react-hooks": "^4.3.0",
     "jest": "^27.4.2",
+    "jest-axe": "^6.0.0",
     "npm-run-all": "4.1.5",
     "stylelint": "13.13.1",
     "stylelint-config-recommended-scss": "4.2.0",
@@ -66,3 +68,4 @@
   "license": "Apache-2.0",
   "private": true
 }
+

--- a/src/components/WorkspaceAdd/WorkspaceAddButton.test.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddButton.test.tsx
@@ -1,0 +1,288 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { toHaveNoViolations, axe } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
+import WorkspaceAddButton from './WorkspaceAddButton';
+
+const workspacesMockData: K8sResourceCommon[] = [
+  {
+    apiVersion: 'v1beta1',
+    apiGroup: 'tenancy.kcp.dev',
+    kind: 'Workspace',
+    metadata: {
+      name: 'demo-ws1',
+    },
+  },
+  {
+    apiVersion: 'v1beta1',
+    apiGroup: 'tenancy.kcp.dev',
+    kind: 'Workspace',
+    metadata: {
+      name: 'demo-ws2',
+    },
+  },
+];
+
+const openModal = () => {
+  fireEvent.click(screen.getByText('Create workspace'));
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+};
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  ...jest.requireActual('@openshift/dynamic-plugin-sdk-utils'),
+  k8sCreateResource: jest.fn(),
+}));
+const k8sCreateResourceMock = k8sCreateResource as jest.Mock;
+
+describe('Add Workspace modal', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    jest.resetModules();
+    k8sCreateResourceMock.mockClear();
+    container = render(<WorkspaceAddButton workspaces={workspacesMockData} />).container;
+  });
+
+  it('Modal opens when user clicks on Create workspace button', () => {
+    // Sanity check to see if component loaded
+    expect(screen.getByText('Create workspace')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    openModal();
+  });
+
+  it('Is accessible', async () => {
+    openModal();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Create button is disabled and name field is empty when modal opens', () => {
+    openModal();
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByText('Create')).toBeDisabled();
+  });
+
+  describe('Create button is disabled if name is not valid', () => {
+    it('Name starts with a dash', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '-workspace' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name starts with an invalid character', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '$workspace' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name starts with a capital letter', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'Workspace' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name has invalid character in the middle', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'work&space' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name has  a capital letter in the middle', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'workSpace' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name ends with a dash', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'workspace-' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name ends with an invalid character', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'workspace$' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+
+    it('Name ends with a capital letter', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'workspacE' },
+      });
+      expect(screen.getByText('Create')).toBeDisabled();
+    });
+  });
+  describe('Create button is enabled with a valid name', () => {
+    it('Name starts with a number', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '1workspace' },
+      });
+      expect(screen.getByText('Create')).not.toBeDisabled();
+    });
+
+    it('Name starts with a lower case letter', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'workspace' },
+      });
+      expect(screen.getByText('Create')).not.toBeDisabled();
+    });
+
+    it('Name has a dash in the middle', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'work-space' },
+      });
+      expect(screen.getByText('Create')).not.toBeDisabled();
+    });
+
+    it('Name ends with a number', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '1workspace1' },
+      });
+      expect(screen.getByText('Create')).not.toBeDisabled();
+    });
+
+    it('Name ends with a lower case letter', () => {
+      openModal();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '1workspace' },
+      });
+      expect(screen.getByText('Create')).not.toBeDisabled();
+    });
+  });
+
+  it('Create button is disabled if name matches an existing name', () => {
+    openModal();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'demo-ws2' },
+    });
+    expect(screen.getByText('Create')).toBeDisabled();
+  });
+
+  it('Error is shown on modal if post fails', async () => {
+    const err = new Error('test error');
+
+    k8sCreateResourceMock.mockRejectedValue(err);
+
+    openModal();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '1workspace' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'tenancy.kcp.dev',
+        apiVersion: 'v1beta1',
+        kind: 'Workspace',
+        plural: 'workspaces',
+      },
+      resource: {
+        apiVersion: 'tenancy.kcp.dev/v1beta1',
+        kind: 'Workspace',
+        metadata: {
+          name: '1workspace',
+        },
+        spec: {
+          type: {
+            name: 'universal',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.queryByRole('dialog')).toBeInTheDocument();
+
+    // Check accessibility of alert
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Modal closes on successfully post', async () => {
+    k8sCreateResourceMock.mockResolvedValue({
+      metadata: {
+        name: '1workspace',
+        uid: 'my-uuid',
+      },
+      spec: {
+        type: {
+          name: 'universal',
+        },
+      },
+    });
+
+    openModal();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '1workspace' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'tenancy.kcp.dev',
+        apiVersion: 'v1beta1',
+        kind: 'Workspace',
+        plural: 'workspaces',
+      },
+      resource: {
+        apiVersion: 'tenancy.kcp.dev/v1beta1',
+        kind: 'Workspace',
+        metadata: {
+          name: '1workspace',
+        },
+        spec: {
+          type: {
+            name: 'universal',
+          },
+        },
+      },
+    });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+});

--- a/src/components/WorkspaceAdd/WorkspaceAddButton.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddButton.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+  ValidatedOptions,
+  FormSelect,
+  FormSelectOption,
+  Form,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import type { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sCreateResource, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+const workspaceTypes = ['universal']; // There isn't an api endpoint to get the list of workspace types yet.
+const workspaceTypeDefault = workspaceTypes[0];
+
+const apiVersion = 'v1beta1';
+const apiGroup = 'tenancy.kcp.dev';
+const kind = 'Workspace';
+
+const WorkspaceModel: K8sModelCommon = {
+  apiVersion,
+  apiGroup,
+  kind,
+  plural: 'workspaces',
+};
+
+const isValidWorkspaceName = (workspaceName: string): boolean => {
+  if (!workspaceName || workspaceName.length > 63) {
+    return false;
+  }
+  return /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/g.test(workspaceName);
+};
+
+const isUniqueName = (workspaceName: string, existingWorkspaces: K8sResourceCommon[] = []) =>
+  !existingWorkspaces.some((workspace) => workspace.metadata.name === workspaceName);
+
+const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] }) => {
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [workspaceName, setWorkspaceName] = React.useState('');
+  const [workspaceType, setWorkspaceType] = React.useState(workspaceTypeDefault);
+  const [isValidName, setIsValidName] = React.useState(ValidatedOptions.default);
+  const [nameExists, setNameExists] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const createWorkspace = () => {
+    setLoading(true);
+
+    k8sCreateResource({
+      model: WorkspaceModel,
+      resource: {
+        apiVersion: `${apiGroup}/${apiVersion}`,
+        kind,
+        metadata: { name: workspaceName },
+        spec: { type: { name: workspaceType } },
+      },
+    })
+      .then((response) => {
+        // eslint-disable-next-line no-console
+        console.log(
+          // @ts-ignore
+          `You have created a ${response.spec.type.name} workspace with a name of ${response.metadata.name} and an UUID of ${response.metadata.uid}`,
+        );
+        setIsModalOpen(!isModalOpen);
+      })
+      .catch((err) => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  React.useEffect(() => {
+    if (!isModalOpen) {
+      setWorkspaceName('');
+      setError('');
+      setWorkspaceType(workspaceTypeDefault);
+      setLoading(false);
+    }
+  }, [isModalOpen]);
+
+  React.useEffect(() => {
+    const validName = isValidWorkspaceName(workspaceName);
+    if (!validName) {
+      setNameExists(false);
+      setIsValidName(ValidatedOptions.error);
+    } else if (!isUniqueName(workspaceName, workspaces)) {
+      setNameExists(true);
+      setIsValidName(ValidatedOptions.error);
+    } else {
+      setIsValidName(ValidatedOptions.success);
+    }
+  }, [workspaceName, workspaces]);
+
+  return (
+    <>
+      <Button onClick={() => setIsModalOpen(true)}>Create workspace</Button>
+      <Modal
+        variant={ModalVariant.small}
+        title="Create a workspace"
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        actions={[
+          !error ? (
+            <Button key="confirm" variant="primary" onClick={createWorkspace} isDisabled={isValidName !== ValidatedOptions.success}>
+              Create
+            </Button>
+          ) : null,
+          <Button key="cancel" variant="link" onClick={() => setIsModalOpen(false)}>
+            {!error ? 'Cancel' : 'Close'}
+          </Button>,
+        ]}
+      >
+        {error ? <Alert variant="danger" isInline title={error} role="alert" /> : null}
+        {loading ? 'Loading ....' : null}
+        {!error && !loading ? (
+          <Form>
+            <FormGroup
+              label="Name"
+              isRequired
+              helperTextInvalid={nameExists ? 'This name already exists' : 'Must only contain letters, numbers, and dashes'}
+              helperTextInvalidIcon={<ExclamationCircleIcon />}
+              validated={isValidName}
+              fieldId="workspace-name"
+            >
+              <TextInput
+                isRequired
+                type="text"
+                value={workspaceName}
+                onChange={setWorkspaceName}
+                validated={isValidName}
+                id="workspace-name"
+                name="workspace-name"
+              />
+            </FormGroup>
+
+            <FormGroup label="Type" fieldId="workspace-type">
+              <FormSelect value={workspaceType} onChange={setWorkspaceType} id="workspace-type" name="workspace-type">
+                {workspaceTypes.map((option, index) => (
+                  <FormSelectOption key={index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </FormGroup>
+          </Form>
+        ) : null}
+      </Modal>
+    </>
+  );
+};
+
+export default WorkspaceAddButton;

--- a/src/components/WorkspaceList/WorkspaceList.tsx
+++ b/src/components/WorkspaceList/WorkspaceList.tsx
@@ -5,6 +5,7 @@ import type { WorkspaceRowData } from './WorkspaceListConfig';
 import { WorkspaceRow, workspaceColumns, workspaceFilters, defaultErrorText } from './WorkspaceListConfig';
 import { Card } from '@patternfly/react-core';
 import type { ListViewLoadError, HttpError } from './utils';
+import WorkspaceAddButton from '../WorkspaceAdd/WorkspaceAddButton';
 
 const watchedResource = {
   isList: true,
@@ -54,6 +55,7 @@ const WorkspaceList: React.FC = () => {
   return (
     <Card>
       <div style={{ overflow: 'scroll' }}>
+        <WorkspaceAddButton workspaces={Array.isArray(workspaces) ? workspaces : [workspaces]} />
         <ListView
           columns={workspaceColumns}
           data={listData}


### PR DESCRIPTION
This is the initial PR to add a modal to create a new workspace. 

Adds a "Create workspace" button on the list of workspaces page. 

**Screen video**


https://user-images.githubusercontent.com/82059948/187110966-7ffe795d-fbf6-4f50-a859-007b246af652.mov



Directions on how to setup the local environment - https://docs.google.com/document/d/1hzoVBBi_694WfmoudtdS9mg1ZWvtox-S7fPYkDnBn5Q

NOTE: There are numerous changes that will be needed to make this fully functional:
 - Addition of the ability to add action buttons (like "Create workspace") to the ListView of the dynamic-plugin-sdk-utils
 - A details page where the user will be directed after a workspace has been successfully created.
 - Check to see if a user has the ability to create a workspace before displaying the create button.
 
 NOTE:  There appears to be an issue with deleting workspaces.  If you create a workspace, deleted it, and try to create another workspace with the same name shortly after the delete, the final creation will fail.  This is reflected in the video above.

Addresses: [HAC-1618](https://issues.redhat.com//browse/HAC-1618)