### PR TITLE
Hac 2164 delete workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@openshift/dynamic-plugin-sdk": "^1.0.0-alpha14",
-        "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha16",
+        "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha17",
         "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha10",
         "@patternfly/react-table": "^4.93.1",
         "@patternfly/react-virtualized-extension": "^4.53.2",
@@ -1210,15 +1210,16 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-utils": {
-      "version": "1.0.0-alpha16",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha16.tgz",
-      "integrity": "sha512-J1m8f2ZIVmxTTXARmAybQL1pmqzL8YxLDF4hFKHBhk3DOvNuGt6Tgd3N4CMCI7dvpvA22hfpwRBKjVzm01S1Jg==",
+      "version": "1.0.0-alpha17",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha17.tgz",
+      "integrity": "sha512-IravFesEE+BNBQgSDq6kAkAPh1U/HbFqefuyE+85gANygcPzzY5AXVOIZC3LoysKMjPOtwYidwpc3nENUZKWGg==",
       "dev": true,
       "dependencies": {
         "immutable": "^3.8.2",
         "lodash-es": "^4.17.21",
         "pluralize": "^8.0.0",
-        "typesafe-actions": "^4.4.2"
+        "typesafe-actions": "^4.4.2",
+        "uuid": "^8.3.2"
       },
       "peerDependencies": {
         "@openshift/dynamic-plugin-sdk": "^1.0.0",
@@ -14673,15 +14674,16 @@
       }
     },
     "@openshift/dynamic-plugin-sdk-utils": {
-      "version": "1.0.0-alpha16",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha16.tgz",
-      "integrity": "sha512-J1m8f2ZIVmxTTXARmAybQL1pmqzL8YxLDF4hFKHBhk3DOvNuGt6Tgd3N4CMCI7dvpvA22hfpwRBKjVzm01S1Jg==",
+      "version": "1.0.0-alpha17",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha17.tgz",
+      "integrity": "sha512-IravFesEE+BNBQgSDq6kAkAPh1U/HbFqefuyE+85gANygcPzzY5AXVOIZC3LoysKMjPOtwYidwpc3nENUZKWGg==",
       "dev": true,
       "requires": {
         "immutable": "^3.8.2",
         "lodash-es": "^4.17.21",
         "pluralize": "^8.0.0",
-        "typesafe-actions": "^4.4.2"
+        "typesafe-actions": "^4.4.2",
+        "uuid": "^8.3.2"
       }
     },
     "@openshift/dynamic-plugin-sdk-webpack": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@openshift/dynamic-plugin-sdk": "^1.0.0-alpha14",
-    "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha16",
+    "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha17",
     "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha10",
     "@patternfly/react-table": "^4.93.1",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
@@ -68,4 +68,3 @@
   "license": "Apache-2.0",
   "private": true
 }
-

--- a/src/components/WorkspaceAdd/WorkspaceAddButton.test.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddButton.test.tsx
@@ -40,12 +40,10 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
 const k8sCreateResourceMock = k8sCreateResource as jest.Mock;
 
 describe('Add Workspace modal', () => {
-  let container: HTMLElement;
-
   beforeEach(() => {
     jest.resetModules();
     k8sCreateResourceMock.mockClear();
-    container = render(<WorkspaceAddButton workspaces={workspacesMockData} />).container;
+    render(<WorkspaceAddButton workspaces={workspacesMockData} />);
   });
 
   it('Modal opens when user clicks on Create workspace button', () => {
@@ -58,7 +56,12 @@ describe('Add Workspace modal', () => {
 
   it('Is accessible', async () => {
     openModal();
-    const results = await axe(container);
+    // Button is accessible
+    let results = await axe(screen.getByText('Create workspace'));
+    expect(results).toHaveNoViolations();
+
+    //Modal is accessible
+    results = await axe(screen.getByRole('dialog'));
     expect(results).toHaveNoViolations();
   });
 
@@ -236,8 +239,8 @@ describe('Add Workspace modal', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
 
-    // Check accessibility of alert
-    const results = await axe(container);
+    // Check accessibility of modal with alert
+    const results = await axe(screen.queryByRole('dialog'));
     expect(results).toHaveNoViolations();
   });
 
@@ -284,5 +287,19 @@ describe('Add Workspace modal', () => {
       },
     });
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('Clicking cancel button closes modal', () => {
+    openModal();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(k8sCreateResourceMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('Clicking cancel "x" closes modal', () => {
+    openModal();
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(k8sCreateResourceMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/src/components/WorkspaceAdd/WorkspaceAddButton.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddButton.tsx
@@ -117,7 +117,7 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
           </Button>,
         ]}
       >
-        {error ? <Alert variant="danger" isInline title={error} role="alert" /> : null}
+        {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
         {loading ? 'Loading ....' : null}
         {!error && !loading ? (
           <Form>

--- a/src/components/WorkspaceDelete/WorkspaceDeleteModal.test.tsx
+++ b/src/components/WorkspaceDelete/WorkspaceDeleteModal.test.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { k8sDeleteResource } from '@openshift/dynamic-plugin-sdk-utils';
+import WorkspaceDeleteModal from './WorkspaceDeleteModal';
+
+expect.extend(toHaveNoViolations);
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  ...jest.requireActual('@openshift/dynamic-plugin-sdk-utils'),
+  k8sDeleteResource: jest.fn(),
+}));
+const k8sDeleteResourceMock = k8sDeleteResource as jest.Mock;
+
+const closeModalMock = jest.fn();
+
+describe('Delete workspace modal', () => {
+  let rerender: any;
+
+  beforeEach(() => {
+    rerender = render(<WorkspaceDeleteModal workspaceName="my-workspace" isOpen closeModal={closeModalMock} />).rerender;
+    jest.resetModules();
+    k8sDeleteResourceMock.mockClear();
+    closeModalMock.mockClear();
+  });
+
+  it('Modal opens when isOpen is set to true', () => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('Modal is not visible when isOpen is set to false', () => {
+    rerender(<WorkspaceDeleteModal workspaceName="my-workspace" isOpen={false} closeModal={closeModalMock} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('Modal is accessible', async () => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const results = await axe(screen.getByRole('dialog'));
+    expect(results).toHaveNoViolations();
+  });
+
+  describe('Delete button is disabled if entered name does not match', () => {
+    it('Entered name is empty', () => {
+      expect(screen.getByRole('textbox')).toHaveValue('');
+      expect(screen.getByText('Delete')).toBeDisabled();
+    });
+
+    it('Entered name is incorrect and not empty', () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'notCorrectName' },
+      });
+      expect(screen.getByText('Delete')).toBeDisabled();
+
+      // check for case sensitivity
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'My-Workspace' },
+      });
+      expect(screen.getByText('Delete')).toBeDisabled();
+    });
+
+    it('Entered name matches and delete button is enabled', () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'my-workspace' },
+      });
+      expect(screen.getByText('Delete')).not.toBeDisabled();
+    });
+  });
+
+  it('Modal entered name field is cleared when modal is re-opened', () => {
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'notCorrectName' },
+    });
+
+    expect(screen.getByRole('textbox')).toHaveValue('notCorrectName');
+
+    // close and open modal
+    rerender(<WorkspaceDeleteModal workspaceName="my-workspace" isOpen={false} closeModal={closeModalMock} />);
+    rerender(<WorkspaceDeleteModal workspaceName="my-workspace" isOpen closeModal={closeModalMock} />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('Error is shown on modal if delete fails', async () => {
+    const err = new Error('test error');
+    k8sDeleteResourceMock.mockRejectedValue(err);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'my-workspace' },
+    });
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'tenancy.kcp.dev',
+        apiVersion: 'v1beta1',
+        kind: 'Workspace',
+        plural: 'workspaces',
+      },
+      queryOptions: {
+        path: 'my-workspace',
+      },
+    });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(closeModalMock).not.toHaveBeenCalled();
+
+    // Check accessibility of modal with alert
+    const results = await axe(screen.queryByRole('dialog'));
+    expect(results).toHaveNoViolations();
+  });
+
+  it('closeModal is called on successful delete', async () => {
+    k8sDeleteResourceMock.mockResolvedValue({});
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'my-workspace' },
+    });
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'tenancy.kcp.dev',
+        apiVersion: 'v1beta1',
+        kind: 'Workspace',
+        plural: 'workspaces',
+      },
+      queryOptions: {
+        path: 'my-workspace',
+      },
+    });
+    await waitFor(() => expect(closeModalMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('Clicking cancel button calls closeModal', () => {
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(k8sDeleteResourceMock).not.toHaveBeenCalled();
+    expect(closeModalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Clicking cancel "x" calls closeModal', () => {
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(k8sDeleteResourceMock).not.toHaveBeenCalled();
+    expect(closeModalMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/WorkspaceDelete/WorkspaceDeleteModal.tsx
+++ b/src/components/WorkspaceDelete/WorkspaceDeleteModal.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Alert, Button, Modal, ModalVariant, TextInput } from '@patternfly/react-core';
+import type { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sDeleteResource } from '@openshift/dynamic-plugin-sdk-utils';
+
+const apiVersion = 'v1beta1';
+const apiGroup = 'tenancy.kcp.dev';
+const kind = 'Workspace';
+
+const WorkspaceModel: K8sModelCommon = {
+  apiVersion,
+  apiGroup,
+  kind,
+  plural: 'workspaces',
+};
+
+const WorkspaceDeleteModal = ({ workspaceName, isOpen, closeModal }: { workspaceName: string; isOpen: boolean; closeModal: () => void }) => {
+  const [confirmText, setConfirmText] = React.useState('');
+  const [error, setError] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    setConfirmText(''), setError('');
+  }, [workspaceName, isOpen]);
+
+  const deleteWorkspace = () => {
+    setLoading(true);
+
+    k8sDeleteResource({ model: WorkspaceModel, queryOptions: { path: workspaceName } })
+      .then(() => {
+        closeModal();
+      })
+      .catch((err) => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return (
+    <>
+      <Modal
+        variant={ModalVariant.small}
+        title="Delete workspace"
+        description={
+          <>
+            <span className="pf-u-color-400">Workspace</span> {workspaceName}
+          </>
+        }
+        isOpen={isOpen}
+        onClose={() => closeModal()}
+        actions={[
+          !error && !loading ? (
+            <Button
+              key="confirm"
+              variant="danger"
+              onClick={() => {
+                deleteWorkspace();
+              }}
+              isDisabled={confirmText !== workspaceName}
+            >
+              Delete
+            </Button>
+          ) : null,
+          <Button key="cancel" variant="link" onClick={() => closeModal()}>
+            {!error ? 'Cancel' : 'Close'}
+          </Button>,
+        ]}
+      >
+        {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
+        {loading ? 'Loading ....' : null}
+        {!error && !loading ? (
+          <>
+            <p> This action cannot be undone. All data will be deleted.</p>
+            <p className="pf-u-my-sm">
+              Confirm deletion by typing <span className="pf-u-font-weight-bold">{workspaceName}</span> below:
+            </p>
+
+            <TextInput
+              type="text"
+              value={confirmText}
+              onChange={setConfirmText}
+              id="workspace-name"
+              name="workspace-name"
+              aria-label={`Type ${workspaceName} to confirm delete`}
+            />
+          </>
+        ) : null}
+      </Modal>
+    </>
+  );
+};
+
+export default WorkspaceDeleteModal;

--- a/src/components/WorkspaceList/WorkspaceList.tsx
+++ b/src/components/WorkspaceList/WorkspaceList.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { ListView, useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import type { WorkspaceRowData } from './WorkspaceListConfig';
-import { WorkspaceRow, workspaceColumns, workspaceFilters, workspaceActions, defaultErrorText } from './WorkspaceListConfig';
+import { WorkspaceRow, workspaceColumns, workspaceFilters, defaultErrorText } from './WorkspaceListConfig';
 import { Card } from '@patternfly/react-core';
+import type { IAction } from '@patternfly/react-table';
 import type { ListViewLoadError, HttpError } from './utils';
 import WorkspaceAddButton from '../WorkspaceAdd/WorkspaceAddButton';
+import WorkspaceDeleteModal from '../WorkspaceDelete/WorkspaceDeleteModal';
 
 const watchedResource = {
   isList: true,
@@ -22,6 +24,8 @@ const WorkspaceList: React.FC = () => {
 
   const [listData, setListData] = React.useState<WorkspaceRowData[]>([]);
   const [listDataError, setListDataError] = React.useState<ListViewLoadError>();
+
+  const [workspaceToDelete, setWorkspaceToDelete] = React.useState('');
 
   const buildListData = React.useCallback(() => {
     let data: WorkspaceRowData[] = [];
@@ -52,10 +56,24 @@ const WorkspaceList: React.FC = () => {
     buildListData();
   }, [buildListData, workspaces]);
 
+  const workspaceActions: IAction[] = [
+    {
+      title: 'Edit workspace',
+      onClick: () => {},
+    },
+    {
+      title: 'Delete workspace',
+      onClick: (event, rowIndex, rowData) => {
+        setWorkspaceToDelete(rowData.name);
+      },
+    },
+  ];
+
   return (
     <Card>
       <div style={{ overflow: 'scroll' }}>
         <WorkspaceAddButton workspaces={Array.isArray(workspaces) ? workspaces : [workspaces]} />
+        <WorkspaceDeleteModal workspaceName={workspaceToDelete} isOpen={!!workspaceToDelete} closeModal={() => setWorkspaceToDelete('')} />
         <ListView
           columns={workspaceColumns}
           data={listData}

--- a/src/components/WorkspaceList/WorkspaceListConfig.tsx
+++ b/src/components/WorkspaceList/WorkspaceListConfig.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import type { IAction } from '@patternfly/react-table';
 import { Td } from '@patternfly/react-table';
 import { Label, Button } from '@patternfly/react-core';
 
@@ -59,16 +58,4 @@ export const workspaceFilters = [
   },
 ];
 
-// Actions on each row
-export const workspaceActions: IAction[] = [
-  {
-    title: 'Edit workspace',
-    onClick: () => null,
-  },
-  {
-    title: 'Delete workspace',
-    onClick: () => null,
-  },
-];
-
-export const defaultErrorText = 'An error occured while retrieving the workspaces';
+export const defaultErrorText = 'An error occurred while retrieving the workspaces';


### PR DESCRIPTION
Adds a delete modal allowing a user to delete a workspace from the workspace list.

**Screenshots**

<img width="1050" alt="Screen Shot 2022-09-20 at 2 40 33 PM" src="https://user-images.githubusercontent.com/82059948/191352840-0c069a20-3580-47a9-84c9-fee45c8de3fc.png">

<img width="1050" alt="Screen Shot 2022-09-20 at 2 40 46 PM" src="https://user-images.githubusercontent.com/82059948/191352870-2b4487c2-fcb2-4078-b9db-be4dabe86c83.png">


**Video**


https://user-images.githubusercontent.com/82059948/191352893-700ac228-1f64-4446-8224-25c9d265fd6c.mov



**NOTES:** 

There is a known issue with the watch hook, so a page refresh is needed right now to remove the deleted workspace from the UI.  Secondly, it appears that it takes a few seconds for the delete to complete, so if you refresh the window too quickly, the deleted workspace will still appear.

To match the CLI, the UI does not check to see if a workspace is empty before deleting.

This requires an updated version of the SDK-utils.