### PR TITLE
HAC-2094: Delete workspace from details page

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -1,6 +1,10 @@
 const { resolve } = require('path');
 const packageInfo = require('../package.json');
 
+const ROUTES = {
+  workspaces: '/workspaces',
+};
+
 module.exports = {
   pluginMetadata: {
     name: packageInfo.name,
@@ -14,7 +18,7 @@ module.exports = {
     {
       type: 'core.page/route',
       properties: {
-        path: '/workspaces',
+        path: ROUTES.workspaces,
         component: {
           $codeRef: 'init',
         },
@@ -23,7 +27,7 @@ module.exports = {
     {
       type: 'core.page/route',
       properties: {
-        path: '/workspaces/:workspaceName',
+        path: `${ROUTES.workspaces}/:workspaceName`,
         component: {
           $codeRef: 'details',
         },
@@ -32,7 +36,7 @@ module.exports = {
     {
       type: 'core.navigation/href',
       properties: {
-        href: '/workspaces',
+        href: ROUTES.workspaces,
         name: 'Workspaces',
       },
     },

--- a/config/routeNames.ts
+++ b/config/routeNames.ts
@@ -1,0 +1,3 @@
+export default {
+  workspaces: '/workspaces',
+};

--- a/src/components/WorkspaceDelete/WorkspaceDeleteModal.test.tsx
+++ b/src/components/WorkspaceDelete/WorkspaceDeleteModal.test.tsx
@@ -11,15 +11,17 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
 const k8sDeleteResourceMock = k8sDeleteResource as jest.Mock;
 
 const closeModalMock = jest.fn();
+const onDeleteMock = jest.fn();
 
 describe('Delete workspace modal', () => {
   let rerender: any;
 
   beforeEach(() => {
-    rerender = render(<WorkspaceDeleteModal workspaceName="my-workspace" isOpen closeModal={closeModalMock} />).rerender;
+    rerender = render(<WorkspaceDeleteModal workspaceName="my-workspace" isOpen closeModal={closeModalMock} onDelete={onDeleteMock} />).rerender;
     jest.resetModules();
     k8sDeleteResourceMock.mockClear();
     closeModalMock.mockClear();
+    onDeleteMock.mockClear();
   });
 
   test('Modal opens when isOpen is set to true', () => {
@@ -103,6 +105,7 @@ describe('Delete workspace modal', () => {
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(closeModalMock).not.toHaveBeenCalled();
+    expect(onDeleteMock).not.toHaveBeenCalled();
 
     // Check accessibility of modal with alert
     const results = await axe(screen.queryByRole('dialog'));
@@ -131,17 +134,20 @@ describe('Delete workspace modal', () => {
       },
     });
     await waitFor(() => expect(closeModalMock).toHaveBeenCalledTimes(1));
+    expect(onDeleteMock).toHaveBeenCalled();
   });
 
   test('Clicking cancel button calls closeModal', () => {
     fireEvent.click(screen.getByText('Cancel'));
     expect(k8sDeleteResourceMock).not.toHaveBeenCalled();
     expect(closeModalMock).toHaveBeenCalledTimes(1);
+    expect(onDeleteMock).not.toHaveBeenCalled();
   });
 
   test('Clicking cancel "x" calls closeModal', () => {
     fireEvent.click(screen.getByLabelText('Close'));
     expect(k8sDeleteResourceMock).not.toHaveBeenCalled();
     expect(closeModalMock).toHaveBeenCalledTimes(1);
+    expect(onDeleteMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/WorkspaceDelete/WorkspaceDeleteModal.tsx
+++ b/src/components/WorkspaceDelete/WorkspaceDeleteModal.tsx
@@ -14,7 +14,14 @@ const WorkspaceModel: K8sModelCommon = {
   plural: 'workspaces',
 };
 
-const WorkspaceDeleteModal = ({ workspaceName, isOpen, closeModal }: { workspaceName: string; isOpen: boolean; closeModal: () => void }) => {
+type WorkspaceDeleteModalProps = {
+  workspaceName: string;
+  isOpen: boolean;
+  closeModal: () => void;
+  onDelete?: () => void;
+};
+
+const WorkspaceDeleteModal = ({ workspaceName, isOpen, closeModal, onDelete }: WorkspaceDeleteModalProps) => {
   const [confirmText, setConfirmText] = React.useState('');
   const [error, setError] = React.useState('');
   const [loading, setLoading] = React.useState(false);
@@ -29,6 +36,7 @@ const WorkspaceDeleteModal = ({ workspaceName, isOpen, closeModal }: { workspace
     k8sDeleteResource({ model: WorkspaceModel, queryOptions: { path: workspaceName } })
       .then(() => {
         closeModal();
+        onDelete();
       })
       .catch((err) => {
         setError(err.message);

--- a/src/components/WorkspaceDetails/WorkspaceDetails.test.tsx
+++ b/src/components/WorkspaceDetails/WorkspaceDetails.test.tsx
@@ -6,6 +6,7 @@ import { createMemoryHistory } from 'history';
 import type { MemoryHistory } from 'history';
 import { k8sGetResource, k8sDeleteResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { WorkspaceDetails } from './index';
+import ROUTES from '../../../config/routeNames';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   ...jest.requireActual('@openshift/dynamic-plugin-sdk-utils'),
@@ -47,7 +48,7 @@ describe('Workspace Details Page', () => {
     k8sGetResourceMock.mockClear();
     k8sDeleteResourceMock.mockClear();
     history = createMemoryHistory();
-    history.push('/workspaces/demo-workspace');
+    history.push(`${ROUTES.workspaces}/demo-workspace`);
     useNavigateMock.mockClear();
   });
 
@@ -94,7 +95,7 @@ describe('Workspace Details Page', () => {
 
       // Verify delete and navigation to the workspace list page
       expect(k8sDeleteResourceMock).toHaveBeenCalled();
-      expect(useNavigateMock).toHaveBeenCalledWith('/workspaces');
+      expect(useNavigateMock).toHaveBeenCalledWith(ROUTES.workspaces);
     });
   });
 

--- a/src/components/WorkspaceDetails/WorkspaceDetails.tsx
+++ b/src/components/WorkspaceDetails/WorkspaceDetails.tsx
@@ -3,6 +3,7 @@ import { DetailsPage, k8sGetResource, K8sModelCommon /* , useK8sWatchResource */
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { PageContentWrapper } from '../common';
 import OverviewTab from './OverviewTab';
+import ROUTES from '../../../config/routeNames';
 import { useParams, useNavigate } from 'react-router-dom';
 
 import WorkspaceDeleteModal from '../WorkspaceDelete/WorkspaceDeleteModal';
@@ -21,14 +22,14 @@ const WorkspaceDetailsTabs = (workspace: K8sResourceCommon, loaded: boolean, err
 };
 
 const WorkspaceDetailsBreadcrumbs = (workspaceName: string) => [
-  { name: 'Workspaces', path: '/workspaces' },
-  { name: 'Workspace Details', path: workspaceName ? `/workspaces/${workspaceName}` : '' },
+  { name: 'Workspaces', path: ROUTES.workspaces },
+  { name: 'Workspace Details', path: workspaceName ? `${ROUTES.workspaces}/${workspaceName}` : '' },
 ];
 
 const WorkspaceActionMenu = (setDeleteModalOpen: (isOpen: boolean) => void) => ({
   actions: [
     {
-      id: '2',
+      id: 'delete',
       label: 'Delete workspace',
       cta: {
         callback: () => {
@@ -106,7 +107,7 @@ const WorkspaceDetails = () => {
         isOpen={deleteModalOpen}
         closeModal={() => setDeleteModalOpen(false)}
         onDelete={() => {
-          navigate('/workspaces');
+          navigate(ROUTES.workspaces);
         }}
       />
       <DetailsPage

--- a/src/components/WorkspaceDetails/WorkspaceDetails.tsx
+++ b/src/components/WorkspaceDetails/WorkspaceDetails.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { DetailsPage, k8sGetResource, K8sModelCommon /* , useK8sWatchResource */ } from '@openshift/dynamic-plugin-sdk-utils';
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { useParams } from 'react-router-dom';
 import { PageContentWrapper } from '../common';
 import OverviewTab from './OverviewTab';
+import { useParams, useNavigate } from 'react-router-dom';
+
+import WorkspaceDeleteModal from '../WorkspaceDelete/WorkspaceDeleteModal';
 
 const PAGE_TITLE = 'Workspace Details';
 
@@ -23,6 +25,21 @@ const WorkspaceDetailsBreadcrumbs = (workspaceName: string) => [
   { name: 'Workspace Details', path: workspaceName ? `/workspaces/${workspaceName}` : '' },
 ];
 
+const WorkspaceActionMenu = (setDeleteModalOpen: (isOpen: boolean) => void) => ({
+  actions: [
+    {
+      id: '2',
+      label: 'Delete workspace',
+      cta: {
+        callback: () => {
+          setDeleteModalOpen(true);
+        },
+      },
+    },
+  ],
+  isDisabled: false,
+});
+
 const WorkspaceModel: K8sModelCommon = {
   apiVersion: 'v1beta1',
   apiGroup: 'tenancy.kcp.dev',
@@ -32,6 +49,7 @@ const WorkspaceModel: K8sModelCommon = {
 
 const WorkspaceDetails = () => {
   const { workspaceName } = useParams();
+  const navigate = useNavigate();
 
   const [workspace, setWorkspace] = React.useState<K8sResourceCommon | undefined>();
   const [loaded, setLoaded] = React.useState(false);
@@ -42,6 +60,7 @@ const WorkspaceDetails = () => {
       }
     | undefined
   >();
+  const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
 
   // Watch isn't currently working
   // const watchedResource = {
@@ -82,11 +101,20 @@ const WorkspaceDetails = () => {
 
   return (
     <PageContentWrapper>
+      <WorkspaceDeleteModal
+        workspaceName={workspace?.metadata?.name}
+        isOpen={deleteModalOpen}
+        closeModal={() => setDeleteModalOpen(false)}
+        onDelete={() => {
+          navigate('/workspaces');
+        }}
+      />
       <DetailsPage
         ariaLabel={PAGE_TITLE}
         tabs={WorkspaceDetailsTabs(workspace, loaded, error)}
         breadcrumbs={WorkspaceDetailsBreadcrumbs(workspace?.metadata?.name)}
         pageHeading={{ title: workspace?.metadata?.name || workspaceName || PAGE_TITLE }}
+        actionMenu={WorkspaceActionMenu(setDeleteModalOpen)}
       />
     </PageContentWrapper>
   );


### PR DESCRIPTION
This allows the user to delete a workspace while viewing the workspace details.   After a successful delete, the user is brought back to the workspace list page.

NOTE: The following PRs need to be merged and published before this can be merged:

- https://github.com/openshift/hac-infra/pull/25
- https://github.com/openshift/dynamic-plugin-sdk/pull/168