### PR TITLE
Show add workspace modal in list header

### DIFF
--- a/src/components/WorkspaceAdd/WorkspaceAddModal.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddModal.tsx
@@ -40,10 +40,9 @@ const isValidWorkspaceName = (workspaceName: string): boolean => {
 const isUniqueName = (workspaceName: string, existingWorkspaces: K8sResourceCommon[] = []) =>
   !existingWorkspaces.some((workspace) => workspace.metadata.name === workspaceName);
 
-const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] }) => {
+const WorkspaceAddModal = ({ workspaces, isOpen, onClose }: { workspaces: K8sResourceCommon[]; isOpen: boolean; onClose: () => void }) => {
   const navigate = useNavigate();
 
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [workspaceName, setWorkspaceName] = React.useState('');
   const [workspaceType, setWorkspaceType] = React.useState(workspaceTypeDefault);
   const [isValidName, setIsValidName] = React.useState(ValidatedOptions.default);
@@ -64,11 +63,9 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
       },
     })
       .then((response) => {
+        onClose();
         if (response?.metadata?.name) {
-          setIsModalOpen(!isModalOpen);
           navigate(`${response.metadata.name}`);
-        } else {
-          throw new Error('Workspace successfully added. Unable to direct to details page.');
         }
       })
       .catch((err) => {
@@ -80,13 +77,13 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
   };
 
   React.useEffect(() => {
-    if (!isModalOpen) {
+    if (!isOpen) {
       setWorkspaceName('');
       setError('');
       setWorkspaceType(workspaceTypeDefault);
       setLoading(false);
     }
-  }, [isModalOpen]);
+  }, [isOpen]);
 
   React.useEffect(() => {
     const validName = isValidWorkspaceName(workspaceName);
@@ -102,59 +99,56 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
   }, [workspaceName, workspaces]);
 
   return (
-    <>
-      <Button onClick={() => setIsModalOpen(true)}>Create workspace</Button>
-      <Modal
-        variant={ModalVariant.small}
-        title="Create a workspace"
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        actions={[
-          !error ? (
-            <Button key="confirm" variant="primary" onClick={createWorkspace} isDisabled={isValidName !== ValidatedOptions.success}>
-              Create
-            </Button>
-          ) : null,
-          <Button key="cancel" variant="link" onClick={() => setIsModalOpen(false)}>
-            {!error ? 'Cancel' : 'Close'}
-          </Button>,
-        ]}
-      >
-        {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
-        {loading ? 'Loading ....' : null}
-        {!error && !loading ? (
-          <Form>
-            <FormGroup
-              label="Name"
+    <Modal
+      variant={ModalVariant.small}
+      title="Create a workspace"
+      isOpen={isOpen}
+      onClose={() => onClose()}
+      actions={[
+        !error ? (
+          <Button key="confirm" variant="primary" onClick={createWorkspace} isDisabled={isValidName !== ValidatedOptions.success}>
+            Create
+          </Button>
+        ) : null,
+        <Button key="cancel" variant="link" onClick={() => onClose()}>
+          {!error ? 'Cancel' : 'Close'}
+        </Button>,
+      ]}
+    >
+      {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
+      {loading ? 'Loading ....' : null}
+      {!error && !loading ? (
+        <Form>
+          <FormGroup
+            label="Name"
+            isRequired
+            helperTextInvalid={nameExists ? 'This name already exists' : 'Must only contain letters, numbers, and dashes'}
+            helperTextInvalidIcon={<ExclamationCircleIcon />}
+            validated={isValidName}
+            fieldId="workspace-name"
+          >
+            <TextInput
               isRequired
-              helperTextInvalid={nameExists ? 'This name already exists' : 'Must only contain letters, numbers, and dashes'}
-              helperTextInvalidIcon={<ExclamationCircleIcon />}
+              type="text"
+              value={workspaceName}
+              onChange={setWorkspaceName}
               validated={isValidName}
-              fieldId="workspace-name"
-            >
-              <TextInput
-                isRequired
-                type="text"
-                value={workspaceName}
-                onChange={setWorkspaceName}
-                validated={isValidName}
-                id="workspace-name"
-                name="workspace-name"
-              />
-            </FormGroup>
+              id="workspace-name"
+              name="workspace-name"
+            />
+          </FormGroup>
 
-            <FormGroup label="Type" fieldId="workspace-type">
-              <FormSelect value={workspaceType} onChange={setWorkspaceType} id="workspace-type" name="workspace-type">
-                {workspaceTypes.map((option, index) => (
-                  <FormSelectOption key={index} value={option} label={option} />
-                ))}
-              </FormSelect>
-            </FormGroup>
-          </Form>
-        ) : null}
-      </Modal>
-    </>
+          <FormGroup label="Type" fieldId="workspace-type">
+            <FormSelect value={workspaceType} onChange={setWorkspaceType} id="workspace-type" name="workspace-type">
+              {workspaceTypes.map((option, index) => (
+                <FormSelectOption key={index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+        </Form>
+      ) : null}
+    </Modal>
   );
 };
 
-export default WorkspaceAddButton;
+export default WorkspaceAddModal;

--- a/src/components/WorkspaceList/WorkspaceList.tsx
+++ b/src/components/WorkspaceList/WorkspaceList.tsx
@@ -6,7 +6,7 @@ import { WorkspaceRow, workspaceColumns, workspaceFilters, defaultErrorText } fr
 import { Card } from '@patternfly/react-core';
 import type { IAction } from '@patternfly/react-table';
 import type { ListViewLoadError, HttpError } from './utils';
-import WorkspaceAddButton from '../WorkspaceAdd/WorkspaceAddButton';
+import WorkspaceAddModal from '../WorkspaceAdd/WorkspaceAddModal';
 import WorkspaceDeleteModal from '../WorkspaceDelete/WorkspaceDeleteModal';
 import { PageContentWrapper } from '../common';
 
@@ -25,6 +25,7 @@ const WorkspaceList: React.FC = () => {
 
   const [listData, setListData] = React.useState<WorkspaceRowData[]>([]);
   const [listDataError, setListDataError] = React.useState<ListViewLoadError>();
+  const [isAddModalOpen, setIsAddModalOpen] = React.useState(false);
 
   const [workspaceToDelete, setWorkspaceToDelete] = React.useState('');
 
@@ -70,10 +71,21 @@ const WorkspaceList: React.FC = () => {
     },
   ];
 
+  const actionButtons = [
+    {
+      label: 'Create workspace',
+      callback: () => setIsAddModalOpen(true),
+    },
+  ];
+
   return (
     <Card>
       <PageContentWrapper>
-        <WorkspaceAddButton workspaces={Array.isArray(workspaces) ? workspaces : [workspaces]} />
+        <WorkspaceAddModal
+          workspaces={Array.isArray(workspaces) ? workspaces : [workspaces]}
+          isOpen={isAddModalOpen}
+          onClose={() => setIsAddModalOpen(false)}
+        />
         <WorkspaceDeleteModal workspaceName={workspaceToDelete} isOpen={!!workspaceToDelete} closeModal={() => setWorkspaceToDelete('')} />
         <ListView
           columns={workspaceColumns}
@@ -85,6 +97,7 @@ const WorkspaceList: React.FC = () => {
           filters={workspaceFilters}
           rowActions={workspaceActions}
           emptyStateDescription="No data was retrieved" // TODO: Add check so that empty payload results in the "Get Started with Workspaces" UI
+          actionButtons={actionButtons}
         />
       </PageContentWrapper>
     </Card>


### PR DESCRIPTION
Move the "add workspace" button into the list view header:

<img width="1306" alt="Screen Shot 2022-10-25 at 3 58 56 PM" src="https://user-images.githubusercontent.com/82059948/197881103-5a6aee35-6fbf-469a-a1ab-9e15c5ce4141.png">


NOTE: This requires the following PR to be merged and published:
https://github.com/openshift/dynamic-plugin-sdk/pull/178


This will also cause conflicts with https://github.com/openshift/hac-infra/pull/25
It is assumed that https://github.com/openshift/hac-infra/pull/25 will be merged first.  To prepare for that, there are commented-out lines of code that will restore functionality where the user is taken to the details page after they create a workspace.