### PR TITLE
Hide create button while adding workspace

### DIFF
--- a/src/components/WorkspaceAdd/WorkspaceAddModal.test.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddModal.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { toHaveNoViolations, axe } from 'jest-axe';
-expect.extend(toHaveNoViolations);
+import { axe } from 'jest-axe';
 
 import { MemoryRouter } from 'react-router-dom';
 
@@ -65,7 +64,7 @@ describe('Add Workspace modal', () => {
 
   test('Create button is disabled and name field is empty when modal opens', () => {
     expect(screen.getByRole('textbox')).toHaveValue('');
-    expect(screen.getByText('Create')).toBeDisabled();
+    expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
   });
 
   describe('Create button is disabled if name is not valid', () => {
@@ -73,92 +72,93 @@ describe('Add Workspace modal', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '-workspace' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name starts with an invalid character', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '$workspace' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name starts with a capital letter', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'Workspace' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name has invalid character in the middle', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'work&space' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name has  a capital letter in the middle', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'workSpace' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name ends with a dash', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'workspace-' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name ends with an invalid character', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'workspace$' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
 
     test('Name ends with a capital letter', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'workspacE' },
       });
-      expect(screen.getByText('Create')).toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
     });
   });
+
   describe('Create button is enabled with a valid name', () => {
     test('Name starts with a number', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '1workspace' },
       });
-      expect(screen.getByText('Create')).not.toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).not.toBeDisabled();
     });
 
     test('Name starts with a lower case letter', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'workspace' },
       });
-      expect(screen.getByText('Create')).not.toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).not.toBeDisabled();
     });
 
     test('Name has a dash in the middle', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'work-space' },
       });
-      expect(screen.getByText('Create')).not.toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).not.toBeDisabled();
     });
 
     test('Name ends with a number', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '1workspace1' },
       });
-      expect(screen.getByText('Create')).not.toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).not.toBeDisabled();
     });
 
     test('Name ends with a lower case letter', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '1workspace' },
       });
-      expect(screen.getByText('Create')).not.toBeDisabled();
+      expect(screen.getByTestId('createWorkspaceButton')).not.toBeDisabled();
     });
   });
 
@@ -166,7 +166,7 @@ describe('Add Workspace modal', () => {
     fireEvent.change(screen.getByRole('textbox'), {
       target: { value: 'demo-ws2' },
     });
-    expect(screen.getByText('Create')).toBeDisabled();
+    expect(screen.getByTestId('createWorkspaceButton')).toBeDisabled();
   });
 
   test('Error is shown on modal if post fails', async () => {
@@ -174,11 +174,13 @@ describe('Add Workspace modal', () => {
 
     k8sCreateResourceMock.mockRejectedValue(err);
 
+    expect(screen.getByTestId('cancelWorkspaceButton')).toHaveTextContent('Cancel');
+
     fireEvent.change(screen.getByRole('textbox'), {
       target: { value: '1workspace' },
     });
 
-    fireEvent.click(screen.getByText('Create'));
+    fireEvent.click(screen.getByTestId('createWorkspaceButton'));
 
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
     expect(k8sCreateResourceMock).toHaveBeenCalledWith({
@@ -203,8 +205,12 @@ describe('Add Workspace modal', () => {
     });
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
-    expect(screen.queryByRole('dialog')).toBeInTheDocument();
+
     expect(mockedUsedNavigate).not.toHaveBeenCalled();
+
+    // Check buttons are in correct state
+    expect(screen.queryByTestId('createWorkspaceButton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cancelWorkspaceButton')).toHaveTextContent('Close');
 
     // Check accessibility of modal with alert
     const results = await axe(screen.queryByRole('dialog'));
@@ -253,6 +259,36 @@ describe('Add Workspace modal', () => {
     });
     await waitFor(() => expect(onCloseMock).toBeCalledTimes(1));
     expect(mockedUsedNavigate).toHaveBeenCalledWith('1workspace');
+  });
+
+  test('Create and cancel buttons are not available when loading', async () => {
+    k8sCreateResourceMock.mockResolvedValue({
+      metadata: {
+        name: '1workspace',
+        uid: 'my-uuid',
+      },
+      spec: {
+        type: {
+          name: 'universal',
+        },
+      },
+    });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '1workspace' },
+    });
+
+    expect(screen.getByTestId('createWorkspaceButton')).toBeInTheDocument();
+    expect(screen.getByTestId('cancelWorkspaceButton')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('createWorkspaceButton'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toBeInTheDocument();
+      // Check to see that the buttons are not showing
+      expect(screen.queryByTestId('createWorkspaceButton')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('cancelWorkspaceButton')).not.toBeInTheDocument();
+    });
   });
 
   test('Clicking cancel button calls onClose', async () => {

--- a/src/components/WorkspaceAdd/WorkspaceAddModal.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddModal.tsx
@@ -40,10 +40,9 @@ const isValidWorkspaceName = (workspaceName: string): boolean => {
 const isUniqueName = (workspaceName: string, existingWorkspaces: K8sResourceCommon[] = []) =>
   !existingWorkspaces.some((workspace) => workspace.metadata.name === workspaceName);
 
-const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] }) => {
+const WorkspaceAddModal = ({ workspaces, isOpen, onClose }: { workspaces: K8sResourceCommon[]; isOpen: boolean; onClose: () => void }) => {
   const navigate = useNavigate();
 
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [workspaceName, setWorkspaceName] = React.useState('');
   const [workspaceType, setWorkspaceType] = React.useState(workspaceTypeDefault);
   const [isValidName, setIsValidName] = React.useState(ValidatedOptions.default);
@@ -64,11 +63,9 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
       },
     })
       .then((response) => {
+        onClose();
         if (response?.metadata?.name) {
-          setIsModalOpen(!isModalOpen);
           navigate(`${response.metadata.name}`);
-        } else {
-          throw new Error('Workspace successfully added. Unable to direct to details page.');
         }
       })
       .catch((err) => {
@@ -80,13 +77,13 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
   };
 
   React.useEffect(() => {
-    if (!isModalOpen) {
+    if (!isOpen) {
       setWorkspaceName('');
       setError('');
       setWorkspaceType(workspaceTypeDefault);
       setLoading(false);
     }
-  }, [isModalOpen]);
+  }, [isOpen]);
 
   React.useEffect(() => {
     const validName = isValidWorkspaceName(workspaceName);
@@ -102,59 +99,56 @@ const WorkspaceAddButton = ({ workspaces }: { workspaces: K8sResourceCommon[] })
   }, [workspaceName, workspaces]);
 
   return (
-    <>
-      <Button onClick={() => setIsModalOpen(true)}>Create workspace</Button>
-      <Modal
-        variant={ModalVariant.small}
-        title="Create a workspace"
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        actions={[
-          !error ? (
-            <Button key="confirm" variant="primary" onClick={createWorkspace} isDisabled={isValidName !== ValidatedOptions.success}>
-              Create
-            </Button>
-          ) : null,
-          <Button key="cancel" variant="link" onClick={() => setIsModalOpen(false)}>
-            {!error ? 'Cancel' : 'Close'}
-          </Button>,
-        ]}
-      >
-        {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
-        {loading ? 'Loading ....' : null}
-        {!error && !loading ? (
-          <Form>
-            <FormGroup
-              label="Name"
+    <Modal
+      variant={ModalVariant.small}
+      title="Create a workspace"
+      isOpen={isOpen}
+      onClose={() => onClose()}
+      actions={[
+        !error ? (
+          <Button key="confirm" variant="primary" onClick={createWorkspace} isDisabled={isValidName !== ValidatedOptions.success}>
+            Create
+          </Button>
+        ) : null,
+        <Button key="cancel" variant="link" onClick={() => onClose()}>
+          {!error ? 'Cancel' : 'Close'}
+        </Button>,
+      ]}
+    >
+      {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
+      {loading ? 'Loading ....' : null}
+      {!error && !loading ? (
+        <Form>
+          <FormGroup
+            label="Name"
+            isRequired
+            helperTextInvalid={nameExists ? 'This name already exists' : 'Must only contain letters, numbers, and dashes'}
+            helperTextInvalidIcon={<ExclamationCircleIcon />}
+            validated={isValidName}
+            fieldId="workspace-name"
+          >
+            <TextInput
               isRequired
-              helperTextInvalid={nameExists ? 'This name already exists' : 'Must only contain letters, numbers, and dashes'}
-              helperTextInvalidIcon={<ExclamationCircleIcon />}
+              type="text"
+              value={workspaceName}
+              onChange={setWorkspaceName}
               validated={isValidName}
-              fieldId="workspace-name"
-            >
-              <TextInput
-                isRequired
-                type="text"
-                value={workspaceName}
-                onChange={setWorkspaceName}
-                validated={isValidName}
-                id="workspace-name"
-                name="workspace-name"
-              />
-            </FormGroup>
+              id="workspace-name"
+              name="workspace-name"
+            />
+          </FormGroup>
 
-            <FormGroup label="Type" fieldId="workspace-type">
-              <FormSelect value={workspaceType} onChange={setWorkspaceType} id="workspace-type" name="workspace-type">
-                {workspaceTypes.map((option, index) => (
-                  <FormSelectOption key={index} value={option} label={option} />
-                ))}
-              </FormSelect>
-            </FormGroup>
-          </Form>
-        ) : null}
-      </Modal>
-    </>
+          <FormGroup label="Type" fieldId="workspace-type">
+            <FormSelect value={workspaceType} onChange={setWorkspaceType} id="workspace-type" name="workspace-type">
+              {workspaceTypes.map((option, index) => (
+                <FormSelectOption key={index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+        </Form>
+      ) : null}
+    </Modal>
   );
 };
 
-export default WorkspaceAddButton;
+export default WorkspaceAddModal;

--- a/src/components/WorkspaceAdd/WorkspaceAddModal.tsx
+++ b/src/components/WorkspaceAdd/WorkspaceAddModal.tsx
@@ -104,19 +104,29 @@ const WorkspaceAddModal = ({ workspaces, isOpen, onClose }: { workspaces: K8sRes
       title="Create a workspace"
       isOpen={isOpen}
       onClose={() => onClose()}
-      actions={[
-        !error ? (
-          <Button key="confirm" variant="primary" onClick={createWorkspace} isDisabled={isValidName !== ValidatedOptions.success}>
-            Create
-          </Button>
-        ) : null,
-        <Button key="cancel" variant="link" onClick={() => onClose()}>
-          {!error ? 'Cancel' : 'Close'}
-        </Button>,
-      ]}
+      actions={
+        !loading
+          ? [
+              !error ? (
+                <Button
+                  key="confirm"
+                  variant="primary"
+                  onClick={createWorkspace}
+                  isDisabled={isValidName !== ValidatedOptions.success}
+                  data-testid="createWorkspaceButton"
+                >
+                  Create
+                </Button>
+              ) : null,
+              <Button key="cancel" variant="link" onClick={() => onClose()} data-testid="cancelWorkspaceButton">
+                {!error ? 'Cancel' : 'Close'}
+              </Button>,
+            ]
+          : []
+      }
     >
       {error ? <Alert variant="danger" isInline title={error} role="alert" titleHeadingLevel="h2" /> : null}
-      {loading ? 'Loading ....' : null}
+      {loading ? <div data-testid="loading">Loading ....</div> : null}
       {!error && !loading ? (
         <Form>
           <FormGroup

--- a/src/components/WorkspaceList/WorkspaceList.tsx
+++ b/src/components/WorkspaceList/WorkspaceList.tsx
@@ -6,7 +6,7 @@ import { WorkspaceRow, workspaceColumns, workspaceFilters, defaultErrorText } fr
 import { Card } from '@patternfly/react-core';
 import type { IAction } from '@patternfly/react-table';
 import type { ListViewLoadError, HttpError } from './utils';
-import WorkspaceAddButton from '../WorkspaceAdd/WorkspaceAddButton';
+import WorkspaceAddModal from '../WorkspaceAdd/WorkspaceAddModal';
 import WorkspaceDeleteModal from '../WorkspaceDelete/WorkspaceDeleteModal';
 import { PageContentWrapper } from '../common';
 
@@ -25,6 +25,7 @@ const WorkspaceList: React.FC = () => {
 
   const [listData, setListData] = React.useState<WorkspaceRowData[]>([]);
   const [listDataError, setListDataError] = React.useState<ListViewLoadError>();
+  const [isAddModalOpen, setIsAddModalOpen] = React.useState(false);
 
   const [workspaceToDelete, setWorkspaceToDelete] = React.useState('');
 
@@ -70,10 +71,21 @@ const WorkspaceList: React.FC = () => {
     },
   ];
 
+  const actionButtons = [
+    {
+      label: 'Create workspace',
+      callback: () => setIsAddModalOpen(true),
+    },
+  ];
+
   return (
     <Card>
       <PageContentWrapper>
-        <WorkspaceAddButton workspaces={Array.isArray(workspaces) ? workspaces : [workspaces]} />
+        <WorkspaceAddModal
+          workspaces={Array.isArray(workspaces) ? workspaces : [workspaces]}
+          isOpen={isAddModalOpen}
+          onClose={() => setIsAddModalOpen(false)}
+        />
         <WorkspaceDeleteModal workspaceName={workspaceToDelete} isOpen={!!workspaceToDelete} closeModal={() => setWorkspaceToDelete('')} />
         <ListView
           columns={workspaceColumns}
@@ -85,6 +97,7 @@ const WorkspaceList: React.FC = () => {
           filters={workspaceFilters}
           rowActions={workspaceActions}
           emptyStateDescription="No data was retrieved" // TODO: Add check so that empty payload results in the "Get Started with Workspaces" UI
+          actionButtons={actionButtons}
         />
       </PageContentWrapper>
     </Card>


### PR DESCRIPTION
There is a slight bug when the api call is being made to create a workspace, the "Create" and "Cancel" buttons are available.  These buttons should be hidden while the api call completes in order to prevent double loading.

**Bug to be fixed**
![Screen Shot 2022-11-01 at 3 32 55 PM](https://user-images.githubusercontent.com/82059948/199335332-ad155210-f4dd-47e1-adcb-10d7aafd319e.png)

**Fixed in this PR**
![Screen Shot 2022-11-01 at 3 33 25 PM](https://user-images.githubusercontent.com/82059948/199335392-31921a35-71ce-477f-8bc3-0f6623d1e790.png)


**Additional Changes**
In the testing file impacted by this change - I moved away from text matching and used testid matching.


NOTE:

This needs to be merged AFTER #27 